### PR TITLE
support optional catch-all routes

### DIFF
--- a/lib/getNetlifyRoute.js
+++ b/lib/getNetlifyRoute.js
@@ -9,7 +9,7 @@
 // also handles catch all routes /[...param]/ -> /:*
 module.exports = dynamicRoute => {
   // replace any catch all group first
-  const expressified = dynamicRoute.replace(/\[\.\.\.(.*)]$/, "*");
+  const expressified = dynamicRoute.replace(/\[{1,2}\.{3}(.*)]{1,2}$/, "*");
 
   // now replace other dynamic route groups
   return expressified.replace(/\[(.*?)]/g, ":$1");


### PR DESCRIPTION
Next.js added a new, experimental, [optional catch-all routes](https://nextjs.org/docs/api-routes/dynamic-api-routes#optional-catch-all-api-routes), this adds support for it by looking for one more wrapping square bracket