### PR TITLE
Adding a missing link to serverless next.js docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install --save next-on-netlify
 
 #### 1. Set NextJS  target to serverless
 
-We must build our NextJS app as a serverless app. You can read more about serverless NextJS here.
+We must build our NextJS app as a serverless app. You can read more about serverless NextJS [here](https://nextjs.org/docs/api-reference/next.config.js/build-target#serverless-target).
 
 It's super simple. Just create a `next.config.js` file and write the following:
 


### PR DESCRIPTION
I'm getting into this project (great stuff, by the way!) and I've noticed a missing link in the docs so I figured - might as well add it 🎉